### PR TITLE
Fixes double click after Make Your Own bug that James encountered

### DIFF
--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -726,6 +726,9 @@ SeedEditor.prototype.setSeedByName = function(seedName) {
 
 SeedEditor.prototype.pickSeed = function() {
   this.reset();
+  if (this.picker.selectedIndex === 0) {
+    globalClearedCanvas = true;
+  }
   if (this.picker.selectedIndex != 0) {
     this.fractalDraw.setSeed(this.stdSeeds[this.picker.selectedIndex]);
     this.fractalDraw.setDrawWidth(this.stdSeedWidth[this.picker.selectedIndex]);


### PR DESCRIPTION
I replicated the bug that happened a few moments ago when you couldn't get double-click to set down the seed shape after clicking Make Your Own. 