### PR TITLE
Makes cancel button work when saving to file

### DIFF
--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -217,6 +217,9 @@ FractalDraw.prototype.loadRemotely = function(evt) {
 FractalDraw.prototype.saveLocally = function() {
   let name = prompt('Please enter the name of the pattern',
     '<name goes here>');
+  if (name === null) {
+    return;
+  }
   let data = {
     'fullname': name,
     'seed': this.seed,


### PR DESCRIPTION
Permits user to click "cancel" when saving locally and not causing the file to be downloaded anyway as null.json

If user enters blankness, it is downloaded as json.json, which is not ideal but better than not working!