### PR TITLE
removes focus, which is causing a scroll jump on page load

### DIFF
--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -606,7 +606,6 @@ function SeedEditor(fractalDraw, enabled) {
   this.workcanvas.onmousedown = this.onMouseDown.bind(this);
 
   this.workcanvas.tabIndex = 1;
-  this.workcanvas.focus();
   this.workcanvas.onkeydown = this.keyPress.bind(this);
 
   this.editMode = SeedEditor.EDITMODE.INIT;


### PR DESCRIPTION
This is causing a page jump when the software is embedded on a web page and the page is loaded. In our case, the page loads and scrolls to the bottom.