### PR TITLE
Changes select to click

### DIFF
--- a/src/example.html
+++ b/src/example.html
@@ -43,7 +43,7 @@
   <div class="container">
 
 
-    <div id="projectListDialog" title="Select A Project">
+    <div id="projectListDialog" title="Click A Project">
       <ol id="projectList" style="list-style-type: none;">
       </ol>
     </div>

--- a/src/example.html
+++ b/src/example.html
@@ -43,7 +43,7 @@
   <div class="container">
 
 
-    <div id="projectListDialog" title="Click A Project">
+    <div id="projectListDialog" title="Select A Project">
       <ol id="projectList" style="list-style-type: none;">
       </ol>
     </div>

--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -182,7 +182,7 @@ FractalDraw.prototype.loadRemotely = function(evt) {
     modal : true,
     buttons : [
             {
-                text : "Select",
+                text : "Open",
                 class : 'Green',
                 click : function() {
                   $( this ).dialog( "close" );


### PR DESCRIPTION
Prof. Eglash had difficulty understanding the cloud loading interface, and request we state that you need to click a project instead of just hitting "select" when there is only one project listed.