### PR TITLE
Fixes the cancelling of a click after deleting node with backspace then clicking on next node

### DIFF
--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -1086,6 +1086,8 @@ SeedEditor.prototype.keyPress = function(evt) {
   let charCode = evt.keyCode || evt.which;
   if ((charCode == 46) || (charCode == 8)) {
     // Delete (or backspace)
+    seedEditorMouseMoved = false;
+    document.removeEventListener ("mousemove" , this.onMouseMove , false);
     if ((this.editMode == SeedEditor.EDITMODE.MOVEPT) &&
       (this.fractalDraw.seed.length > 2)) {
       this.fractalDraw.deleteFromSeed(this.movePt);

--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -1088,6 +1088,7 @@ SeedEditor.prototype.keyPress = function(evt) {
     // Delete (or backspace)
     seedEditorMouseMoved = false;
     document.removeEventListener ("mousemove" , this.onMouseMove , false);
+    document.removeEventListener ("mouseup" , this.onMouseUp , false);
     if ((this.editMode == SeedEditor.EDITMODE.MOVEPT) &&
       (this.fractalDraw.seed.length > 2)) {
       this.fractalDraw.deleteFromSeed(this.movePt);


### PR DESCRIPTION
Bug:

After deleting a node and single-clicking a node to move, it was automatically cancelling the click. This is because the delete option left the mouse state in limbo and the seedEditorMouseMoved was set to true, even though it needed to be reset to false. 

This wraps up the mouse state by setting the seedEditorMouseMoved global to false and deleting the mousemove event listener.