### PR TITLE
Fixes seed.length == 2 bug where if you click delete when node active…

### DIFF
--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -1086,7 +1086,8 @@ SeedEditor.prototype.keyPress = function(evt) {
   let charCode = evt.keyCode || evt.which;
   if ((charCode == 46) || (charCode == 8)) {
     // Delete (or backspace)
-    if (this.editMode == SeedEditor.EDITMODE.MOVEPT && this.fractalDraw.seed.length > 2) {
+    if (this.editMode == SeedEditor.EDITMODE.MOVEPT && 
+      (this.fractalDraw.seed.length > 2)) {
       seedEditorMouseMoved = false;
       document.removeEventListener ("mousemove" , this.onMouseMove , false);
       document.removeEventListener ("mouseup" , this.onMouseUp , false);

--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -1086,9 +1086,11 @@ SeedEditor.prototype.keyPress = function(evt) {
   let charCode = evt.keyCode || evt.which;
   if ((charCode == 46) || (charCode == 8)) {
     // Delete (or backspace)
-    seedEditorMouseMoved = false;
-    document.removeEventListener ("mousemove" , this.onMouseMove , false);
-    document.removeEventListener ("mouseup" , this.onMouseUp , false);
+    if (this.editMode === 3 && this.fractalDraw.seed.length != 2) {
+      seedEditorMouseMoved = false;
+      document.removeEventListener ("mousemove" , this.onMouseMove , false);
+      document.removeEventListener ("mouseup" , this.onMouseUp , false);
+    }
     if ((this.editMode == SeedEditor.EDITMODE.MOVEPT) &&
       (this.fractalDraw.seed.length > 2)) {
       this.fractalDraw.deleteFromSeed(this.movePt);

--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -1086,7 +1086,7 @@ SeedEditor.prototype.keyPress = function(evt) {
   let charCode = evt.keyCode || evt.which;
   if ((charCode == 46) || (charCode == 8)) {
     // Delete (or backspace)
-    if (this.editMode === SeedEditor.EDITMODE.MOVEPT && this.fractalDraw.seed.length > 2) {
+    if (this.editMode == SeedEditor.EDITMODE.MOVEPT && this.fractalDraw.seed.length > 2) {
       seedEditorMouseMoved = false;
       document.removeEventListener ("mousemove" , this.onMouseMove , false);
       document.removeEventListener ("mouseup" , this.onMouseUp , false);

--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -1086,7 +1086,7 @@ SeedEditor.prototype.keyPress = function(evt) {
   let charCode = evt.keyCode || evt.which;
   if ((charCode == 46) || (charCode == 8)) {
     // Delete (or backspace)
-    if (this.editMode === 3 && this.fractalDraw.seed.length != 2) {
+    if (this.editMode === SeedEditor.EDITMODE.MOVEPT && this.fractalDraw.seed.length != 2) {
       seedEditorMouseMoved = false;
       document.removeEventListener ("mousemove" , this.onMouseMove , false);
       document.removeEventListener ("mouseup" , this.onMouseUp , false);

--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -1086,7 +1086,7 @@ SeedEditor.prototype.keyPress = function(evt) {
   let charCode = evt.keyCode || evt.which;
   if ((charCode == 46) || (charCode == 8)) {
     // Delete (or backspace)
-    if (this.editMode === SeedEditor.EDITMODE.MOVEPT && this.fractalDraw.seed.length != 2) {
+    if (this.editMode === SeedEditor.EDITMODE.MOVEPT && this.fractalDraw.seed.length > 2) {
       seedEditorMouseMoved = false;
       document.removeEventListener ("mousemove" , this.onMouseMove , false);
       document.removeEventListener ("mouseup" , this.onMouseUp , false);


### PR DESCRIPTION
Fixes seed.length == 2 bug (just a single line as seed shape) where if you click delete when node is active it won't place afterwards, because it was removing the mouseup event listener.