### PR TITLE
Double click color change fix

### DIFF
--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -945,6 +945,7 @@ SeedEditor.prototype.mouseMove = function(evt) {
 // Global Variables for mouse handling, since click and mousedown conflict.
 let seedEditorMouseMoved = false;
 let seedEditorDoubleClick = false;
+let globalColorClock = function() {};
 
 SeedEditor.prototype.onMouseDown = function(evt) {
   /* Clone of SeedEditor.prototype.mouseClick's
@@ -1068,11 +1069,21 @@ SeedEditor.prototype.mouseClick = function(evt) {
       this.drawWork();
       this.setMode(SeedEditor.EDITMODE.MOVEPT);
     } else {
-      let closestLn = this.fractalDraw.closestLn([this.rawX, this.rawY]);
-      if (closestLn >= 0) {
-        seed[closestLn + 1][2] = this.currentSegType;
-        this.fractalDraw.drawSeed(true);
+      placeColor = () => {
+        let closestLn = this.fractalDraw.closestLn([this.rawX, this.rawY]);
+        if (closestLn >= 0) {
+          seed[closestLn + 1][2] = this.currentSegType;
+          this.fractalDraw.drawSeed(true); 
+        }
       }
+      this.placeColorCallback = () => {
+        this.colorTimer = setTimeout(() => { 
+          placeColor();
+        }, 500);
+      }
+      this.placeColorCallback();
+          
+      
     }
   } else if (this.editMode == SeedEditor.EDITMODE.MOVEPT) {
     if (this.movePt >= 0) {
@@ -1116,6 +1127,7 @@ SeedEditor.prototype.keyPress = function(evt) {
 
 SeedEditor.prototype.mouseDblClick = function(evt) {
   globalClearedCanvas = false;
+  clearTimeout(this.placeColorCallback);
   if (this.editMode == SeedEditor.EDITMODE.DEFINING) {
     this.getMousePos(evt);
     this.fractalDraw.addToSeed([this.mouseX, this.mouseY, this.currentSegType]);

--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -945,7 +945,6 @@ SeedEditor.prototype.mouseMove = function(evt) {
 // Global Variables for mouse handling, since click and mousedown conflict.
 let seedEditorMouseMoved = false;
 let seedEditorDoubleClick = false;
-let globalColorClock = function() {};
 
 SeedEditor.prototype.onMouseDown = function(evt) {
   /* Clone of SeedEditor.prototype.mouseClick's

--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -1076,6 +1076,10 @@ SeedEditor.prototype.mouseClick = function(evt) {
           this.fractalDraw.drawSeed(true); 
         }
       }
+      if (this.colorTimer) {
+        clearTimeout(this.colorTimer);
+        this.colorTimer = null;
+      }
       this.placeColorCallback = () => {
         this.colorTimer = setTimeout(() => { 
           placeColor();
@@ -1127,7 +1131,8 @@ SeedEditor.prototype.keyPress = function(evt) {
 
 SeedEditor.prototype.mouseDblClick = function(evt) {
   globalClearedCanvas = false;
-  clearTimeout(this.placeColorCallback);
+  clearTimeout(this.colorTimer);
+  this.colorTimer = null;
   if (this.editMode == SeedEditor.EDITMODE.DEFINING) {
     this.getMousePos(evt);
     this.fractalDraw.addToSeed([this.mouseX, this.mouseY, this.currentSegType]);


### PR DESCRIPTION
When double clicking on the canvas, two single clicks are automatically fired before every double click. This was causing the line you are splitting in half to become the color of the currently selected segment color, because the single click was changing the color of the line before it was split by the double click. This has been fixed by adding a .5s timeout that is cancelled if a double click is fired. The code was already set up to preserve line color when double clicking, so there were no modifications to perform. Obviously there is a .5s delay when clicking to change a color, but it is hardly noticeable compared to the poor UX experience of having the color of a line change every time you split it.