### PR TITLE
Thickness type

### DIFF
--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -751,7 +751,7 @@ function SeedEditor(fractalDraw, enabled) {
   panelTD.appendChild(this.thicknessBox);
 
   let thicknessBoxLabel = document.createElement('span');
-  thicknessBoxLabel.innerHTML = ' Width decreases with recursion';
+  thicknessBoxLabel.innerHTML = ' Thin with recursion';
   panelTD.appendChild(thicknessBoxLabel);
 
 


### PR DESCRIPTION
Closes #37 

* Adds a "thin with recursion" checkbox to edit mode which subtracts one from each line width per recursion.

* Allows loading of seeds from drop-down menu to automatically turn on and off the "thin with recursion" checkmark, using the "thicknesstype" value in the seed object.