### PR TITLE
gets project number through query string

### DIFF
--- a/src/fracexpl.js
+++ b/src/fracexpl.js
@@ -2290,12 +2290,38 @@ function MultiModeTool(mainDiv, toolNum, askWidth, askHeight, instanceNum) {
         cloud.loadProject(mainDiv.dataset['seed'], myself.load.bind(myself), error);
       } else {
         this.editorDiv.setSeedByName(mainDiv.dataset['seed']);
+        function testQueryStringExist(queryKey) {
+          var field = queryKey || 'q';
+          var url = window.location.href;
+          if(url.indexOf('?' + field + '=') != -1)
+              return true;
+          else if(url.indexOf('&' + field + '=') != -1)
+              return true;
+          return false
+        }
+        function getParameterByName(name, url) {
+          if (!url) url = window.location.href;
+          name = name.replace(/[\[\]]/g, "\\$&");
+          var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+              results = regex.exec(url);
+          if (!results) return null;
+          if (!results[2]) return '';
+          return decodeURIComponent(results[2].replace(/\+/g, " "));
+        }
+        let queryKeyword = 'project';
+        if (testQueryStringExist(queryKeyword)) {
+          let projNum = getParameterByName(queryKeyword);
+          if (Number.isInteger(projNum)) {
+            cloud.loadProject(projNum, myself.load.bind(myself), error);
+          }
+        }
       }
     }
     catch (err) {
       console.log(err);
     }
   }
+
 
   let mode = 1;
   if ((mainDiv.dataset['mode'] != undefined) &&


### PR DESCRIPTION
Gets a project number through a query string (currently 'project') and loads it. This will be used in combination with django to load a fractal project from the project detail menu using RedirectView. This is a more robust method than using django to serve a template, because it doesn't duplicate HTML code under a django template.